### PR TITLE
STORM-528

### DIFF
--- a/storm-core/src/jvm/backtype/storm/task/WorkerTopologyContext.java
+++ b/storm-core/src/jvm/backtype/storm/task/WorkerTopologyContext.java
@@ -88,6 +88,15 @@ public class WorkerTopologyContext extends GeneralTopologyContext {
     }
 
     /**
+     * Sets the location of the external resources for this worker on the
+     * local filesystem. These external resources typically include bolts implemented
+     * in other languages, such as Ruby or Python.
+     */
+    public void setCodeDir(String codeDir) {
+        _codeDir = codeDir;
+    }
+
+    /**
      * If this task spawns any subprocesses, those subprocesses must immediately
      * write their PID to this directory on the local filesystem to ensure that
      * Storm properly destroys that process when the worker is shutdown.

--- a/storm-core/src/ui/public/templates/component-page-template.html
+++ b/storm-core/src/ui/public/templates/component-page-template.html
@@ -479,7 +479,7 @@
         <td>{{errorHost}}</td>
         <td><a href="{{errorWorkerLogLink}}">{{errorPort}}</a></td>
         <td>
-          <span id="{{errorLapsedSecs}}" class="errorSpan"><a href="{{errorWorkerLogLink}}">{{error}}</a></span>
+          <span id="{{errorLapsedSecs}}" class="errorSpan">{{error}}</span>
         </td>
       </tr>
       {{/componentErrors}}

--- a/storm-core/src/ui/public/templates/topology-page-template.html
+++ b/storm-core/src/ui/public/templates/topology-page-template.html
@@ -331,7 +331,7 @@
         <td>{{errorHost}}</td>
         <td><a href="{{errorWorkerLogLink}}">{{errorPort}}</a></td>
         <td>
-          <span id="{{errorLapsedSecs}}" class="errorSpan"><a href="{{errorWorkerLogLink}}">{{lastError}}</a></span>
+          <span id="{{errorLapsedSecs}}" class="errorSpan">{{lastError}}</span>
         </td>
         {{/bolts}}
     </tbody>

--- a/storm-core/src/ui/public/templates/topology-page-template.html
+++ b/storm-core/src/ui/public/templates/topology-page-template.html
@@ -242,7 +242,7 @@
         <td>{{errorHost}}</td>
         <td><a href="{{errorWorkerLogLink}}">{{errorPort}}</a></td>
         <td>
-          <span id="{{errorLapsedSecs}}" class="errorSpan"><a href="{{errorWorkerLogLink}}">{{lastError}}</a></span>
+          <span id="{{errorLapsedSecs}}" class="errorSpan">{{lastError}}</span>
         </td>
         {{/spouts}}
     </tbody>


### PR DESCRIPTION
@harshach - For https://issues.apache.org/jira/browse/STORM-528
The overriding of codeDir is intended to remove duplicates python, ruby, js external resources in codebase. ATM, I have not intentionally updated all clients to use this signature to override codeDir as that would change API drastically, and need consensus.
